### PR TITLE
feat: Zero-fill gaps in statistics and backfill from first gap

### DIFF
--- a/custom_components/helen_energy/statistics.py
+++ b/custom_components/helen_energy/statistics.py
@@ -195,7 +195,7 @@ class HelenStatisticsManager:
 
 				# Find the first zero consumption hour with a previous hour
                 for prev_hour, curr_hour in zip(hours, hours[1:]):
-                    if existing_consumption[curr_hour] == 0.0:
+                    if existing_consumption[curr_hour] == existing_consumption[prev_hour]:
                         first_zero_hour = (prev_hour, curr_hour)
                         break
 
@@ -237,9 +237,10 @@ class HelenStatisticsManager:
             electricity = self._extract_electricity_value(entry) if entry else None
             spot_price = self._extract_spot_price_value(entry) if entry else None
 
-            if electricity is None or spot_price is None:
-                # Zero-fill gaps instead of stopping
+			# Zero-fill gaps instead of stopping
+            if electricity is None:
                 electricity = 0.0
+            if spot_price is None:
                 spot_price = 0.0
                 '''
                 age_hours = (now_utc - current_hour).total_seconds() / 3600

--- a/custom_components/helen_energy/statistics.py
+++ b/custom_components/helen_energy/statistics.py
@@ -108,8 +108,8 @@ class HelenStatisticsManager:
     ) -> None:
         """Write the cumulative statistics chain from the given series.
 
-        In extend mode (default): anchors to the last DB record inside the API
-        window and appends only new hours after it.
+        In extend mode (default): anchors to the last DB record before the first gap
+        inside the API window and (over)writes hours after it.
 
         In rebuild mode: anchors to the last DB record *before* the API window
         (30-day lookback) and overwrites the full range via upsert. Used by the
@@ -175,7 +175,7 @@ class HelenStatisticsManager:
                 latest_api.isoformat(),
             )
         else:
-            # Extend mode: continue from wherever the chain left off.
+            # Extend mode: start from first gap or continue from last entry.
             window_end = now_utc + timedelta(hours=1)
             existing_consumption = await self._get_existing_statistics_in_window(
                 self.consumption_statistic_id, earliest_api, window_end
@@ -190,11 +190,28 @@ class HelenStatisticsManager:
                 )
 
             if existing_consumption:
-                last_db_hour = max(existing_consumption.keys())
-                cumulative_consumption = existing_consumption[last_db_hour]
-                cumulative_cost = existing_cost.get(last_db_hour, 0.0)
-                cumulative_fixed_cost = existing_fixed_cost.get(last_db_hour, 0.0)
-                walk_start = last_db_hour + timedelta(hours=1)
+                hours = tuple(existing_consumption.keys())
+                first_zero_hour = None
+
+				# Find the first zero consumption hour with a previous hour
+                for prev_hour, curr_hour in zip(hours, hours[1:]):
+                    if existing_consumption[curr_hour] == 0.0:
+                        first_zero_hour = (prev_hour, curr_hour)
+                        break
+
+                if first_zero_hour is not None:
+                    # Get consumption and costs of previous hour
+                    cumulative_consumption = existing_consumption[first_zero_hour[0]]
+                    cumulative_cost = existing_cost.get(first_zero_hour[0], 0.0)
+                    cumulative_fixed_cost = existing_fixed_cost.get(first_zero_hour[0], 0.0)
+                    # Start filling from the first applicable zero consumption hour
+                    walk_start = first_zero_hour[1]
+                else:
+                    last_db_hour = max(existing_consumption.keys())
+                    cumulative_consumption = existing_consumption[last_db_hour]
+                    cumulative_cost = existing_cost.get(last_db_hour, 0.0)
+                    cumulative_fixed_cost = existing_fixed_cost.get(last_db_hour, 0.0)
+                    walk_start = last_db_hour + timedelta(hours=1)
             else:
                 cumulative_consumption = 0.0
                 cumulative_cost = 0.0
@@ -221,6 +238,10 @@ class HelenStatisticsManager:
             spot_price = self._extract_spot_price_value(entry) if entry else None
 
             if electricity is None or spot_price is None:
+                # Zero-fill gaps instead of stopping
+                electricity = 0.0
+                spot_price = 0.0
+                '''
                 age_hours = (now_utc - current_hour).total_seconds() / 3600
                 if age_hours > STATISTICS_MAX_GAP_WAIT_HOURS:
                     electricity = 0.0
@@ -240,6 +261,7 @@ class HelenStatisticsManager:
                         STATISTICS_MAX_GAP_WAIT_HOURS,
                     )
                     break
+                '''
 
             hourly_cost = electricity * spot_price
             hourly_fixed_cost = (


### PR DESCRIPTION
Oma Helen has gaps almost daily for my contract, so HA is constantly lagging days behind.
Made these changes so that the gaps are zero-filled instead of stopping on them and the extend mode backfill now starts from the first gap inside the window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data completeness: missing hourly electricity consumption or spot price values are now immediately zero-filled rather than waiting, reducing processing delays.
  * Enhanced historical data extension: the system now anchors to the last complete hour before the first detected gap, ensuring more consistent data reconciliation during statistics updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->